### PR TITLE
Fix PartEnum usage and clean imports

### DIFF
--- a/api/v1/endpoints/attendance.py
+++ b/api/v1/endpoints/attendance.py
@@ -1,7 +1,6 @@
 from sqlalchemy import func, select
 from fastapi import APIRouter, Depends, HTTPException, Form, Query
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.future import select
 from db.session import get_db
 from models.attendance import Attendance, AttendanceStatus
 from models.group import PartEnum

--- a/api/v1/endpoints/group.py
+++ b/api/v1/endpoints/group.py
@@ -14,13 +14,6 @@ from models.attendance import Attendance, AttendanceStatus
 from models.group import Group, Team, TeamUser, PartEnum
 from models.user import User, RoleEnum, GenderEnum
 
-# 로컬 모듈
-from db.session import get_db
-from models.attendance import Attendance, AttendanceStatus
-from models.group import Group, Team, TeamUser, PartEnum
-from models.user import User
-from models.user import RoleEnum
-
 router = APIRouter()
 
 @router.post("/create")
@@ -194,7 +187,10 @@ async def shuffle_teams(group_id: int, db: AsyncSession = Depends(get_db)):
     balanced_distribute(females2, part2_teams)
 
     # 7. 저장 (1부/2부 모두)
-    for part, team_users in [(PartEnum.part1, part1_teams), (PartEnum.part2, part2_teams)]:
+    for part, team_users in [
+        (PartEnum.FIRST, part1_teams),
+        (PartEnum.SECOND, part2_teams),
+    ]:
         for i, members in enumerate(team_users):
             team = Team(group_id=group_id, part=part)
             db.add(team)

--- a/api/v1/endpoints/user.py
+++ b/api/v1/endpoints/user.py
@@ -5,7 +5,6 @@ from db.session import get_db
 from models.user import User, RoleEnum, GenderEnum
 from models.group import Group
 from models.attendance import Attendance
-from sqlalchemy.future import select
 
 router = APIRouter()
 


### PR DESCRIPTION
## Summary
- fix incorrect PartEnum attribute names in group endpoints
- remove duplicate imports and clean headers in API endpoints

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684827c9da788330926feb1d47856844