### PR TITLE
Add meeting counts and new Korean labels

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -2,7 +2,7 @@
 <html lang="ko">
 <head>
   <meta charset="UTF-8" />
-  <title>관리자 페이지</title>
+  <title>강서구 영어회화 모임 관리자</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="/static/style.css" />
   <style>
@@ -141,7 +141,7 @@
   </script>
 
   <header>
-    <h1>소모임 관리자 페이지</h1>
+    <h1>강서구 영어회화 모임 관리자 페이지</h1>
   </header>
 
   <main>
@@ -213,8 +213,8 @@
 
     <section>
       <h2>🗓️ 모임 목록</h2>
-      <button onclick="loadGroups()">모임 불러오기</button>
-      <ul id="group-list"></ul>
+      <button id="toggle-group-list">모임 불러오기</button>
+      <ul id="group-list" style="display:none;"></ul>
     </section>
 
     <section style="margin-top: 2rem;">

--- a/static/admin.js
+++ b/static/admin.js
@@ -156,6 +156,19 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   };
 
+  const bindGroupListToggle = () => {
+    const toggleBtn = document.getElementById("toggle-group-list");
+    const list = document.getElementById("group-list");
+    if (!toggleBtn || !list) return;
+    list.style.display = "none";
+    toggleBtn.onclick = () => {
+      const isHidden = list.style.display === "none";
+      list.style.display = isHidden ? "block" : "none";
+      toggleBtn.textContent = isHidden ? "접기" : "모임 불러오기";
+      if (isHidden) loadGroups();
+    };
+  };
+
   // 📄 모임 목록 로딩
   async function loadGroups() {
     try {
@@ -165,9 +178,11 @@ document.addEventListener("DOMContentLoaded", () => {
       ul.innerHTML = "";
 
       groups.forEach(g => {
+        const first = g.part_counts?.first || { admin: 0, member: 0 };
+        const second = g.part_counts?.second || { admin: 0, member: 0 };
         const li = document.createElement("li");
         li.className = "group-item";
-        li.textContent = g.date;
+        li.innerHTML = `${g.date} - 1부 운영진 ${first.admin}명 회원 ${first.member}명, 2부 운영진 ${second.admin}명 회원 ${second.member}명`;
         li.dataset.groupId = g.id;
         li.onclick = () => {
           document.querySelectorAll("#group-list .group-item").forEach(el => el.classList.remove("selected"));
@@ -234,7 +249,7 @@ document.addEventListener("DOMContentLoaded", () => {
   bindUserForm();
   bindUserListToggle();
   bindGroupForm();
-  loadGroups();
+  bindGroupListToggle();
   window.loadUsers = loadUsers;
   window.loadGroups = loadGroups;
 });

--- a/static/index.html
+++ b/static/index.html
@@ -2,13 +2,13 @@
 <html lang="ko">
 <head>
   <meta charset="UTF-8" />
-  <title>소모임 메인</title>
+  <title>강서구 영어회화 모임 메인</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="/static/style.css" />
 </head>
 <body>
   <header>
-    <h1>소모임 참여 현황</h1>
+    <h1>강서구 영어회화 모임 참여 현황</h1>
     <p id="user-info" class="user-info" aria-live="polite"></p>
     <p id="current-datetime" class="clock-display" aria-live="polite"></p>
     <div id="admin-link-container" class="admin-link"></div>
@@ -17,12 +17,13 @@
   <main>
     <section class="group-section" aria-label="모임 목록">
       <h2>📅 모임 목록</h2>
+      <button id="toggle-group-list">모임 불러오기</button>
       <ul id="group-list" class="group-list" role="list"></ul>
     </section>
   </main>
 
   <footer>
-    <p>© 2025 소모임 관리 서비스</p>
+    <p>© 2025 강서구 영어회화 모임</p>
   </footer>
 
   <!-- 🔽 스크립트는 DOM 뒤에 로드되도록 배치 -->

--- a/static/index.js
+++ b/static/index.js
@@ -11,7 +11,7 @@ window.addEventListener("DOMContentLoaded", () => {
   renderUserInfo();
   renderAdminLink();
   startClock();
-  loadGroups();
+  bindGroupListToggle();
 });
 
 function renderUserInfo() {
@@ -60,14 +60,17 @@ async function loadGroups() {
 
       li.innerHTML = `
         <p>📅 ${group.date}</p>
-        ${PART_LABELS.map(label => `
+        ${PART_LABELS.map(label => {
+            const enumKey = PART_LABEL_TO_ENUM[label];
+            const c = group.part_counts?.[enumKey] || { admin: 0, member: 0 };
+            return `
           <div class="part-section" data-part-label="${label}">
-            <strong>${label}</strong>
+            <strong>${label} - 운영진 ${c.admin}명 회원 ${c.member}명</strong>
             <span class="attend-msg" data-part-label="${label}">⏳ 상태 확인 중...</span><br/>
             <button class="attend-btn" data-part-label="${label}" ${isToday ? "disabled" : ""}>참석</button>
             <button class="absent-btn" data-part-label="${label}" ${isToday ? "disabled" : ""}>불참</button>
-          </div>
-        `).join("")}
+          </div>`;
+        }).join("")}
         <div class="team-toggle">
           <button class="toggle-team-btn" data-open="false">🧩 조 편성 보기</button>
           <div class="team-box" style="display:none;"></div>
@@ -193,4 +196,17 @@ async function getTeamHTML(groupId, groupDate) {
   return `<h4>🧩 ${groupDate} 조 편성 결과</h4>` +
          renderPart("📘 1부 조편성", part1) +
          renderPart("📙 2부 조편성", part2);
+}
+
+function bindGroupListToggle() {
+  const toggleBtn = document.getElementById("toggle-group-list");
+  const list = document.getElementById("group-list");
+  if (!toggleBtn || !list) return;
+  list.style.display = "none";
+  toggleBtn.onclick = () => {
+    const isHidden = list.style.display === "none";
+    list.style.display = isHidden ? "block" : "none";
+    toggleBtn.textContent = isHidden ? "접기" : "모임 불러오기";
+    if (isHidden) loadGroups();
+  };
 }

--- a/static/login.html
+++ b/static/login.html
@@ -2,14 +2,14 @@
 <html lang="ko">
 <head>
   <meta charset="UTF-8" />
-  <title>소모임 로그인</title>
+  <title>강서구 영어회화 모임 로그인</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="/static/style.css" />
   <link rel="stylesheet" href="/static/login.css" />
 </head>
 <body>
   <div class="login-container">
-    <h1>소모임 로그인</h1>
+    <h1>강서구 영어회화 모임 로그인</h1>
 
     <form id="login-form">
       <label for="email">이메일</label>


### PR DESCRIPTION
## Summary
- update `/groups/list` API to return part counts
- show admin/member counts per part on frontend
- toggle for meeting list loading
- rebrand pages for **강서구 영어회화 모임**

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684832f7f6b08330a68c2b8ae60567dd