### PR TITLE
Load group list automatically

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -17,7 +17,7 @@
   <main>
     <section class="group-section" aria-label="모임 목록">
       <h2>📅 모임 목록</h2>
-      <button id="toggle-group-list">모임 불러오기</button>
+      <button id="toggle-group-list">접기</button>
       <ul id="group-list" class="group-list" role="list"></ul>
     </section>
   </main>

--- a/static/index.js
+++ b/static/index.js
@@ -12,6 +12,11 @@ window.addEventListener("DOMContentLoaded", () => {
   renderAdminLink();
   startClock();
   bindGroupListToggle();
+  loadGroups();
+  const list = document.getElementById("group-list");
+  if (list) list.style.display = "block";
+  const toggleBtn = document.getElementById("toggle-group-list");
+  if (toggleBtn) toggleBtn.textContent = "접기";
 });
 
 function renderUserInfo() {
@@ -202,7 +207,7 @@ function bindGroupListToggle() {
   const toggleBtn = document.getElementById("toggle-group-list");
   const list = document.getElementById("group-list");
   if (!toggleBtn || !list) return;
-  list.style.display = "none";
+  // 목록을 기본으로 보여주고 필요 시 새로고침용으로 사용
   toggleBtn.onclick = () => {
     const isHidden = list.style.display === "none";
     list.style.display = isHidden ? "block" : "none";


### PR DESCRIPTION
## Summary
- show group list automatically on page load
- allow toggle button to refresh or hide list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848357300e083309aeec4fc5bc5b60d