### PR TITLE
Fix enum mapping for attendance records

### DIFF
--- a/models/attendance.py
+++ b/models/attendance.py
@@ -16,7 +16,14 @@ class Attendance(Base):
     id = Column(Integer, primary_key=True)
     group_id = Column(Integer, ForeignKey("groups.id"))
     user_id = Column(Integer, ForeignKey("users.id"))
-    part = Column(Enum(PartEnum), nullable=False)  # ✅ 1부/2부 구분 필드 추가
+    part = Column(
+        Enum(
+            PartEnum,
+            values_callable=lambda x: [e.value for e in x],
+            native_enum=False,
+        ),
+        nullable=False,
+    )  # ✅ 1부/2부 구분 필드 추가 - store enum values
     status = Column(Enum(AttendanceStatus), nullable=False)
 
     __table_args__ = (

--- a/models/group.py
+++ b/models/group.py
@@ -19,7 +19,15 @@ class Team(Base):
     __tablename__ = "teams"
     id = Column(Integer, primary_key=True, index=True)
     group_id = Column(Integer, ForeignKey("groups.id"))
-    part = Column(Enum(PartEnum), nullable=False)  # 1부 / 2부
+    # Store enum values ("first"/"second") instead of names ("FIRST"/"SECOND")
+    part = Column(
+        Enum(
+            PartEnum,
+            values_callable=lambda x: [e.value for e in x],
+            native_enum=False,
+        ),
+        nullable=False,
+    )  # 1부 / 2부
     group = relationship("Group", back_populates="teams")
     members = relationship("TeamUser", back_populates="team", cascade="all, delete-orphan")
 


### PR DESCRIPTION
## Summary
- fix enum storage for teams and attendance to use enum values
- ensure compatibility with existing lowercase data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68497fb0878883308b2a98e54ba4e0a3