### PR TITLE
Prevent duplicate team assignment per part

### DIFF
--- a/api/v1/endpoints/group.py
+++ b/api/v1/endpoints/group.py
@@ -216,7 +216,15 @@ async def shuffle_teams(
         db.add(team)
         await db.flush()
         for user in members:
-            db.add(TeamUser(team_id=team.id, user_id=user.id, is_leader=(user.id == team_leaders[i].id)))
+            db.add(
+                TeamUser(
+                    team_id=team.id,
+                    user_id=user.id,
+                    group_id=group_id,
+                    part=part_enum,
+                    is_leader=(user.id == team_leaders[i].id),
+                )
+            )
 
     await db.commit()
     return {"message": "조 편성이 완료되었습니다.", "조 수": team_count, "총원": total_count}

--- a/models/group.py
+++ b/models/group.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, Date, ForeignKey, Enum, Boolean
+from sqlalchemy import Column, Integer, Date, ForeignKey, Enum, Boolean, UniqueConstraint
 from sqlalchemy.orm import relationship
 from sqlalchemy.ext.declarative import declarative_base
 import enum
@@ -36,7 +36,22 @@ class TeamUser(Base):
     id = Column(Integer, primary_key=True)
     team_id = Column(Integer, ForeignKey("teams.id"))
     user_id = Column(Integer, ForeignKey("users.id"))
+    # 중복 배정을 방지하기 위해 그룹과 부 정보를 명시적으로 저장
+    group_id = Column(Integer, nullable=False)
+    part = Column(
+        Enum(
+            PartEnum,
+            values_callable=lambda x: [e.value for e in x],
+            native_enum=False,
+        ),
+        nullable=False,
+    )
     is_leader = Column(Boolean, default=False)
+
+    __table_args__ = (
+        # 한 유저가 같은 부에서 두 개 이상의 팀에 속할 수 없도록 제한
+        UniqueConstraint("group_id", "part", "user_id", name="_group_part_user_uc"),
+    )
 
     team = relationship("Team", back_populates="members")
     user = relationship("User")


### PR DESCRIPTION
## Summary
- enforce unique (group, part, user) constraint on `TeamUser`
- store group and part in `TeamUser` rows
- update shuffle logic to populate these new fields

## Testing
- `pip install -r requirements.txt`
- `pip install pytest pytest-asyncio httpx python-multipart`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499d9a514083309c1ecafe97cdff9c