### PR TITLE
Add reset option to database init

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,13 @@ main.py             FastAPI application entrypoint
 2. **Initialise the database**
 
    ```bash
-   python db/init_db.py
+   python db/init_db.py --reset
    # (Optional) populate with sample users
    python db/seed_users.py
    ```
+
+   If you update the models and encounter errors like `no column named group_id`,
+   rerun the initialisation with the `--reset` flag to recreate all tables.
 
 3. **Run the application**
 

--- a/db/init_db.py
+++ b/db/init_db.py
@@ -3,11 +3,34 @@ import asyncio
 from db.session import engine
 from models import user, group, attendance
 
-async def init_db():
+async def init_db(reset: bool = False):
+    """Initialise the database.
+
+    Parameters
+    ----------
+    reset: bool
+        Drop existing tables before creating them again.  Useful when the
+        schema has changed and the SQLite file still exists.
+    """
+
     async with engine.begin() as conn:
+        if reset:
+            await conn.run_sync(attendance.Base.metadata.drop_all)
+            await conn.run_sync(group.Base.metadata.drop_all)
+            await conn.run_sync(user.Base.metadata.drop_all)
         await conn.run_sync(user.Base.metadata.create_all)
         await conn.run_sync(group.Base.metadata.create_all)
         await conn.run_sync(attendance.Base.metadata.create_all)
 
 if __name__ == "__main__":
-    asyncio.run(init_db())
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Initialise the database")
+    parser.add_argument(
+        "--reset",
+        action="store_true",
+        help="Drop existing tables before creating them",
+    )
+    args = parser.parse_args()
+
+    asyncio.run(init_db(reset=args.reset))


### PR DESCRIPTION
## Summary
- add a `--reset` argument to `init_db.py` so old tables can be dropped
- document using this flag in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499f3982348330a86a3ffa22cadd65