### PR TITLE
Implement basic logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project is a simple attendance and group management service built with **Fa
 
 ```
 api/                FastAPI routers and endpoints
-core/               configuration files (currently empty)
+core/               application configuration and middleware (e.g. logging)
 db/                 database session and initialisation scripts
 models/             SQLAlchemy model definitions
 services/           service layer (placeholder)
@@ -69,4 +69,5 @@ They cover authentication and run against an in-memory SQLite database.
 
 - The application stores data in `app.db` in the project root when running locally.
 - Static files are served from the `static/` directory.
+- Logs are written to `app.log` and rotated automatically.
 

--- a/core/logging_setup.py
+++ b/core/logging_setup.py
@@ -1,0 +1,26 @@
+import logging
+from logging.handlers import RotatingFileHandler
+
+
+def setup_logging(log_file: str = "app.log", level: int = logging.INFO) -> None:
+    """Configure root logger for the application.
+
+    Parameters
+    ----------
+    log_file: str
+        Path to the log file. Defaults to ``app.log`` in the project root.
+    level: int
+        Logging level. Defaults to ``logging.INFO``.
+    """
+    logger = logging.getLogger()
+    if logger.handlers:
+        # Already configured
+        return
+
+    logger.setLevel(level)
+    handler = RotatingFileHandler(log_file, maxBytes=1_000_000, backupCount=3, encoding="utf-8")
+    formatter = logging.Formatter(
+        "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
+    )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -1,0 +1,18 @@
+import logging
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+logger = logging.getLogger(__name__)
+
+
+class LoggingMiddleware(BaseHTTPMiddleware):
+    """Simple middleware that logs request and response information."""
+
+    async def dispatch(self, request: Request, call_next):
+        logger.info("Request: %s %s", request.method, request.url.path)
+        response = await call_next(request)
+        logger.info(
+            "Response: %s %s -> %s", request.method, request.url.path, response.status_code
+        )
+        return response

--- a/main.py
+++ b/main.py
@@ -4,9 +4,15 @@ from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 
+from core.logging_setup import setup_logging
+from core.middleware import LoggingMiddleware
+
 from api.v1.router import api_router
 
+setup_logging()
+
 app = FastAPI()
+app.add_middleware(LoggingMiddleware)
 app.include_router(api_router, prefix="/api/v1")
 
 static_dir = os.path.join(os.path.dirname(__file__), "static")


### PR DESCRIPTION
## Summary
- add logging setup with rotation
- log request/response info via middleware
- wire middleware into FastAPI app
- document logging in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af603687083308f439a101463192a