### PR TITLE
Improve main page controls

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -31,10 +31,11 @@ function renderUserInfo() {
 function renderAdminLink() {
   const adminLinkContainer = document.getElementById("admin-link-container");
   if (["운영진", "모임장"].includes(user?.role)) {
-    const btn = document.createElement("a");
-    btn.href = "/admin";
-    btn.textContent = "🔧 관리자 페이지";
-    btn.className = "admin-link";
+    const btn = document.createElement("button");
+    btn.textContent = "어드민 페이지";
+    btn.onclick = () => {
+      window.location.href = "/admin";
+    };
     adminLinkContainer.appendChild(btn);
   }
 }
@@ -233,8 +234,10 @@ function bindGroupListToggle() {
   toggleBtn.onclick = () => {
     const isHidden = list.style.display === "none";
     list.style.display = isHidden ? "block" : "none";
-    toggleBtn.textContent = isHidden ? "접기" : "모임 불러오기";
-    if (isHidden) loadGroups();
+    toggleBtn.textContent = isHidden ? "접기" : "목록 열기";
+    if (isHidden && list.innerHTML.trim() === "") {
+      loadGroups();
+    }
   };
 }
 
@@ -242,8 +245,12 @@ function bindGroupSearch() {
   const input = document.getElementById("group-search");
   if (!input) return;
   input.addEventListener("input", () => {
-    const term = input.value.trim();
-    const filtered = allGroups.filter(g => g.date.includes(term));
+    const term = input.value.trim().replace(/[^0-9]/g, "");
+    if (!term) {
+      renderGroups(allGroups);
+      return;
+    }
+    const filtered = allGroups.filter(g => g.date.replace(/[^0-9]/g, "").includes(term));
     renderGroups(filtered);
   });
 }

--- a/static/style.css
+++ b/static/style.css
@@ -24,6 +24,20 @@ header, footer {
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
+#admin-link-container button {
+  margin-top: 0.5rem;
+  padding: 0.4rem 0.8rem;
+  border: none;
+  border-radius: 6px;
+  background-color: var(--color-primary);
+  color: var(--color-light);
+  cursor: pointer;
+}
+
+#admin-link-container button:hover {
+  background-color: var(--color-primary-dark);
+}
+
 main {
   padding: 2rem;
   max-width: 800px;


### PR DESCRIPTION
## Summary
- add admin button in header to jump to admin page
- fix group list toggle to just show/hide and reload when empty
- make date search more robust and allow digits only
- style the new admin button

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c0c81488c8330bcd5a77d528d79a1