### PR TITLE
Fix group list toggle and remove date search

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -18,7 +18,6 @@
     <section class="group-section" aria-label="모임 목록">
       <h2>📅 모임 목록</h2>
       <button id="toggle-group-list">접기</button>
-      <input id="group-search" type="text" placeholder="날짜 검색" />
       <ul id="group-list" class="group-list" role="list"></ul>
     </section>
   </main>

--- a/static/index.js
+++ b/static/index.js
@@ -13,7 +13,6 @@ window.addEventListener("DOMContentLoaded", () => {
   renderAdminLink();
   startClock();
   bindGroupListToggle();
-  bindGroupSearch();
   loadGroups();
   const list = document.getElementById("group-list");
   if (list) list.style.display = "block";
@@ -152,10 +151,7 @@ function renderGroups(groups) {
 
       ul.appendChild(li);
     }
-  } catch (e) {
-    console.error("모임 목록 로딩 실패", e);
   }
-}
 
 async function setAttendance(groupId, apiPart, status, msgElem) {
   const form = new FormData();
@@ -241,16 +237,3 @@ function bindGroupListToggle() {
   };
 }
 
-function bindGroupSearch() {
-  const input = document.getElementById("group-search");
-  if (!input) return;
-  input.addEventListener("input", () => {
-    const term = input.value.trim().replace(/[^0-9]/g, "");
-    if (!term) {
-      renderGroups(allGroups);
-      return;
-    }
-    const filtered = allGroups.filter(g => g.date.replace(/[^0-9]/g, "").includes(term));
-    renderGroups(filtered);
-  });
-}


### PR DESCRIPTION
## Summary
- remove unused date search field on main page
- fix JavaScript parse error by removing stray catch block
- load groups and toggle list correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c0e96af248330b0a30250e63ffb44